### PR TITLE
Fix logging warning typo and 3D plot label

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -253,7 +253,7 @@ async def process_api_requests_from_file(
                     )
                     await asyncio.sleep(remaining_seconds_to_pause)
                     # ^e.g., if pause is 15 seconds and final limit was hit 5 seconds ago
-                    logging.warn(
+                    logging.warning(
                         f"Pausing to cool down until {time.ctime(status_tracker.time_of_last_rate_limit_error + seconds_to_pause_after_rate_limit_error)}"
                     )
 

--- a/examples/utils/embeddings_utils.py
+++ b/examples/utils/embeddings_utils.py
@@ -221,7 +221,7 @@ def chart_from_components_3D(
     strings: Optional[List[str]] = None,
     x_title: str = "Component 0",
     y_title: str = "Component 1",
-    z_title: str = "Compontent 2",
+    z_title: str = "Component 2",
     mark_size: int = 5,
     **kwargs,
 ):


### PR DESCRIPTION
## Summary
- fix deprecated `logging.warn` call in `api_request_parallel_processor.py`
- correct axis label typo in `chart_from_components_3D`

## Testing
- `python -m py_compile examples/api_request_parallel_processor.py examples/utils/embeddings_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68416c509d08832cac1763da3546ba5e