### PR TITLE
Add Flask portfolio example

### DIFF
--- a/examples/portfolio_flask/README.md
+++ b/examples/portfolio_flask/README.md
@@ -1,0 +1,32 @@
+# Flask Portfolio Example
+
+This folder contains a minimal portfolio website with a basic CMS built using Flask.
+
+## Features
+
+- Public pages:
+  - **Home** page listing visible projects
+  - **About** page with contact information
+  - **Project detail** page for each project
+- Admin pages:
+  - Hard-coded login (`admin`/`password`)
+  - Dashboard with list of all projects
+  - Create, edit, and delete project entries
+  - Toggle visibility of projects
+- Project data stored in a simple JSON file
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install flask
+   ```
+2. Start the app:
+   ```bash
+   python app.py
+   ```
+3. Visit `http://127.0.0.1:5000` in your browser.
+
+## Deployment
+
+This example can be deployed on services like [Render](https://render.com) using a free tier web service. Point the service to `python app.py` for the start command.

--- a/examples/portfolio_flask/app.py
+++ b/examples/portfolio_flask/app.py
@@ -1,0 +1,141 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+import json
+import os
+
+app = Flask(__name__)
+app.secret_key = "supersecretkey"  # simple session key
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), 'data', 'projects.json')
+
+# Utility functions
+
+def load_projects():
+    if not os.path.exists(DATA_FILE):
+        return []
+    with open(DATA_FILE, 'r') as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return []
+
+
+def save_projects(projects):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(projects, f, indent=2)
+
+
+def get_project(slug):
+    for proj in load_projects():
+        if proj.get('slug') == slug:
+            return proj
+    return None
+
+# Public routes
+
+@app.route('/')
+def index():
+    projects = [p for p in load_projects() if p.get('visible')]
+    return render_template('index.html', projects=projects)
+
+
+@app.route('/about')
+def about():
+    return render_template('about.html')
+
+
+@app.route('/projects/<slug>')
+def project_detail(slug):
+    project = get_project(slug)
+    if not project or not project.get('visible'):
+        return "Project not found", 404
+    return render_template('detail.html', project=project)
+
+# Admin routes
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if username == 'admin' and password == 'password':
+            session['logged_in'] = True
+            return redirect(url_for('dashboard'))
+        return render_template('login.html', error='Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.pop('logged_in', None)
+    return redirect(url_for('index'))
+
+
+def login_required(func):
+    from functools import wraps
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not session.get('logged_in'):
+            return redirect(url_for('login'))
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@app.route('/admin')
+@login_required
+def dashboard():
+    projects = load_projects()
+    return render_template('dashboard.html', projects=projects)
+
+
+@app.route('/admin/edit/<slug>', methods=['GET', 'POST'])
+@login_required
+def edit_project(slug):
+    projects = load_projects()
+    project = next((p for p in projects if p.get('slug') == slug), None)
+    if request.method == 'POST':
+        if not project:
+            project = {'slug': slug}
+            projects.append(project)
+        project['title'] = request.form.get('title')
+        project['image'] = request.form.get('image')
+        project['description'] = request.form.get('description')
+        project['tags'] = request.form.get('tags').split(',') if request.form.get('tags') else []
+        project['visible'] = request.form.get('visible') == 'on'
+        save_projects(projects)
+        return redirect(url_for('dashboard'))
+    return render_template('edit_project.html', project=project)
+
+
+@app.route('/admin/delete/<slug>', methods=['POST'])
+@login_required
+def delete_project(slug):
+    projects = load_projects()
+    projects = [p for p in projects if p.get('slug') != slug]
+    save_projects(projects)
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/admin/new', methods=['GET', 'POST'])
+@login_required
+def new_project():
+    if request.method == 'POST':
+        slug = request.form.get('slug')
+        projects = load_projects()
+        if get_project(slug):
+            return render_template('edit_project.html', error='Slug already exists')
+        project = {
+            'slug': slug,
+            'title': request.form.get('title'),
+            'image': request.form.get('image'),
+            'description': request.form.get('description'),
+            'tags': request.form.get('tags').split(',') if request.form.get('tags') else [],
+            'visible': request.form.get('visible') == 'on'
+        }
+        projects.append(project)
+        save_projects(projects)
+        return redirect(url_for('dashboard'))
+    return render_template('edit_project.html', project={})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/examples/portfolio_flask/data/projects.json
+++ b/examples/portfolio_flask/data/projects.json
@@ -1,0 +1,10 @@
+[
+  {
+    "slug": "example-project",
+    "title": "Example Project",
+    "image": "https://via.placeholder.com/300",
+    "description": "This is an example project description.",
+    "tags": ["demo", "flask"],
+    "visible": true
+  }
+]

--- a/examples/portfolio_flask/static/script.js
+++ b/examples/portfolio_flask/static/script.js
@@ -1,0 +1,1 @@
+// You can add custom JavaScript here

--- a/examples/portfolio_flask/static/styles.css
+++ b/examples/portfolio_flask/static/styles.css
@@ -1,0 +1,3 @@
+body {
+  padding-top: 60px;
+}

--- a/examples/portfolio_flask/templates/about.html
+++ b/examples/portfolio_flask/templates/about.html
@@ -1,0 +1,6 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>About Me</h1>
+<p>This is where you can write something about yourself.</p>
+<p>Contact: <a href="mailto:you@example.com">you@example.com</a></p>
+{% endblock %}

--- a/examples/portfolio_flask/templates/dashboard.html
+++ b/examples/portfolio_flask/templates/dashboard.html
@@ -1,0 +1,30 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Admin Dashboard</h1>
+<a href="{{ url_for('new_project') }}" class="btn btn-success mb-3">Add Project</a>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Slug</th>
+      <th>Visible</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for project in projects %}
+    <tr>
+      <td>{{ project.title }}</td>
+      <td>{{ project.slug }}</td>
+      <td>{{ 'Yes' if project.visible else 'No' }}</td>
+      <td>
+        <a href="{{ url_for('edit_project', slug=project.slug) }}" class="btn btn-primary btn-sm">Edit</a>
+        <form action="{{ url_for('delete_project', slug=project.slug) }}" method="post" class="d-inline">
+          <button class="btn btn-danger btn-sm" onclick="return confirm('Delete project?')">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/examples/portfolio_flask/templates/detail.html
+++ b/examples/portfolio_flask/templates/detail.html
@@ -1,0 +1,8 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>{{ project.title }}</h1>
+<img src="{{ project.image }}" class="img-fluid mb-3" alt="{{ project.title }}">
+<p>{{ project.description }}</p>
+<p><strong>Tags:</strong> {{ project.tags | join(', ') }}</p>
+<a href="{{ url_for('index') }}" class="btn btn-secondary">Back</a>
+{% endblock %}

--- a/examples/portfolio_flask/templates/edit_project.html
+++ b/examples/portfolio_flask/templates/edit_project.html
@@ -1,0 +1,34 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>{{ project.slug and 'Edit' or 'New' }} Project</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post">
+  {% if not project.slug %}
+  <div class="mb-3">
+    <label class="form-label">Slug</label>
+    <input type="text" name="slug" class="form-control" required>
+  </div>
+  {% endif %}
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="{{ project.title }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Image URL</label>
+    <input type="text" name="image" class="form-control" value="{{ project.image }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="5">{{ project.description }}</textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tags (comma separated)</label>
+    <input type="text" name="tags" class="form-control" value="{{ project.tags | join(', ') }}">
+  </div>
+  <div class="form-check mb-3">
+    <input type="checkbox" name="visible" class="form-check-input" {% if project.visible %}checked{% endif %}>
+    <label class="form-check-label">Visible</label>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/examples/portfolio_flask/templates/index.html
+++ b/examples/portfolio_flask/templates/index.html
@@ -1,0 +1,18 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1 class="mb-4">Projects</h1>
+<div class="row row-cols-1 row-cols-md-3 g-4">
+  {% for project in projects %}
+  <div class="col">
+    <div class="card h-100">
+      <img src="{{ project.image }}" class="card-img-top" alt="{{ project.title }}">
+      <div class="card-body">
+        <h5 class="card-title">{{ project.title }}</h5>
+        <p class="card-text">{{ project.description[:100] }}...</p>
+        <a href="{{ url_for('project_detail', slug=project.slug) }}" class="btn btn-primary">Read more</a>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/examples/portfolio_flask/templates/layout.html
+++ b/examples/portfolio_flask/templates/layout.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title if title else 'Portfolio' }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Portfolio</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">Home</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('about') }}">About</a></li>
+            {% if session.get('logged_in') %}
+              <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a></li>
+              <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+            {% else %}
+              <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Login</a></li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container py-4">
+      {% block content %}{% endblock %}
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+  </body>
+</html>

--- a/examples/portfolio_flask/templates/login.html
+++ b/examples/portfolio_flask/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Login</h1>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a simple Flask-based portfolio with a minimal CMS
- include templates, static files and example data
- document how to run and deploy the app

## Testing
- `pip install flask`
- `python -m py_compile examples/portfolio_flask/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687774793944832c8418fa65fecedeca